### PR TITLE
introduce .wrap_lines() to produce lines wrapped to console width

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hca
 Title: Exploring the Human Cell Atlas Data Coordinating Platform
-Version: 0.99.6
+Version: 0.99.7
 Authors@R:
     c(person(given = "Maya",
            family = "McDaniel",

--- a/R/filters.R
+++ b/R/filters.R
@@ -63,10 +63,10 @@ facet_options <- function() {
     facets <- facet_options()
     if (!all(names(x) %in% facets)) {
         ## invalid facet message
-        facet_msg <- paste0(
+        facet_msg <- .wrap_lines(c(
             "'filters()' facets must be one of: ",
             paste(facets, collapse = ", ")
-        )
+        ))
         stop(facet_msg)
     }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -42,3 +42,19 @@
 .is_catalog <- function(x, na.ok = FALSE) {
     .is_scalar_character(x) && (x %in% catalogs())
 }
+
+## wrap lines to output width, with 2-character 'exdent' of lines
+## after the first
+
+.wrap_lines <-
+    function(x, exdent = 2)
+{
+    ## create a length-1 string
+    x <- paste(x, collapse = " ")
+
+    ## break into lines of fixed width
+    lines <- strwrap(x, exdent = exdent)
+
+    ## collapse into a single string with embedded new lines
+    paste(lines, collapse = "\n")
+}        

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -19,3 +19,22 @@ test_that("'.is_scalar_*()' works", {
 test_that("'.is_scalar_character()' nzchar works", {
     expect_true(.is_scalar_character(""))
 })
+
+test_that("'.wrap_lines()' wraps lines", {
+    oopt = options(width = 15)
+    on.exit(options(oopt))
+
+    x <- "one word or another"
+    expected <- "one word or\n  another"
+    expect_identical(.wrap_lines(x), expected)
+    expect_identical(.wrap_lines(strsplit(x, " ")[[1]]), expected)
+
+    ## leading / trailing whitespace trimmed
+    expect_identical(.wrap_lines(c("one word or ", "another")), expected)
+    expect_identical(.wrap_lines(c("one word or ", " another ")), expected)
+
+    ## edge cases
+    expect_identical(.wrap_lines(character()), "")
+    expect_identical(.wrap_lines(""), "")
+    expect_identical(.wrap_lines(c("one word or", "", "another")), expected)
+})


### PR DESCRIPTION
- intended for messages, etc., seen by the user, e.g., facet_options() error
  that might span multiple lines
- adjusts to getOption("width") and hence to, for example RStudio console
  width